### PR TITLE
Remove CRLF from action_descs when saving to file

### DIFF
--- a/src/olc/olc_obj.c
+++ b/src/olc/olc_obj.c
@@ -229,6 +229,11 @@ save_objs(struct creature * ch, struct zone_data * zone)
 
         if (obj->action_desc) {
             tmp = strlen(obj->action_desc);
+
+            if (tmp >= 2 && obj->action_desc[tmp-2] == '\r' && obj->action_desc[tmp-1] == '\n') {
+                obj->action_desc[tmp-2] = '\0';
+            }
+
             for (i = 0; i < tmp; i++)
                 if (obj->action_desc[i] != '\r')
                     fputc(obj->action_desc[i], file);


### PR DESCRIPTION
Resolves an issue in #157. For this change in particular, please test in your branch. It has the potential to corrupt obj files, so I'm hoping you can try to break it yourself in dev.
