### PR TITLE
Fix killing blow messages

### DIFF
--- a/src/combat/fight.c
+++ b/src/combat/fight.c
@@ -1904,6 +1904,8 @@ damage(struct creature *ch, struct creature *victim,
         }
     }
 
+    update_pos(victim);
+    
     /*
      * skill_message sends a message from the messages file in lib/misc.
      * dam_message just sends a generic "You hit $n extremely hard.".


### PR DESCRIPTION
When killing something you just get the standard damage message instead of the death message. This fixes that problem.

This call was taken out a while back, because (I think), it was considered unnecessary. It updates the position of the victim so that when the message in skill_message is being decided it knows that the victim is dead. Without it, the victim isn't in POS_DEAD so it doesn't know to use the death message.