### PR TITLE
Fix punctuation in mail attachments message

### DIFF
--- a/src/editor/maileditor.c
+++ b/src/editor/maileditor.c
@@ -341,7 +341,7 @@ maileditor_addattachment(struct editor *editor, char *obj_name)
 
     if (mail_data->num_attachments >= MAX_MAIL_ATTACHMENTS) {
         editor_emit(editor, "You may not attach any more packages to "
-            "this mail\r\n");
+            "this mail.\r\n");
         return;
     }
 


### PR DESCRIPTION
Simply adds a missing period at the end of a message for reaching the maximum attachments to a mail.