### PR TITLE
Fix message for invisible group when splitting

### DIFF
--- a/src/misc/act.other.c
+++ b/src/misc/act.other.c
@@ -712,7 +712,9 @@ ACMD(do_split)
             GET_CASH(k) += share;
         else
             GET_GOLD(k) += share;
-        send_to_char(k, "%s splits %'d %s; you receive %'d.\r\n", GET_NAME(ch),
+
+        send_to_char(k, "%s splits %'d %s; you receive %'d.\r\n", 
+            can_see_creature(k, ch) ? GET_NAME(ch) : "Someone",
             amount, mode ? "credits" : "coins", share);
     }
     for (f = k->followers; f; f = f->next) {
@@ -723,8 +725,10 @@ ACMD(do_split)
                 GET_CASH(f->follower) += share;
             else
                 GET_GOLD(f->follower) += share;
+
             send_to_char(f->follower, "%s splits %'d %s; you receive %'d.\r\n",
-                GET_NAME(ch), amount, mode ? "credits" : "coins", share);
+                can_see_creature(f->follower, ch) ? GET_NAME(ch) : "Someone", 
+                amount, mode ? "credits" : "coins", share);
         }
     }
     send_to_char(ch, "You split %'d %s among %d member%s -- %'d each.\r\n",


### PR DESCRIPTION
This fixes an issue where when a group member split money his name would show up to group members that could not see him.