### PR TITLE
add year to board message list

### DIFF
--- a/src/objects/boards.c
+++ b/src/objects/boards.c
@@ -290,7 +290,7 @@ gen_board_list(struct board_data *board, struct creature *ch)
 
     for (idx = 0; idx < count; idx++) {
         post_time = atol(PQgetvalue(res, idx, 0));
-        strftime(time_buf, 30, "%a %b %e", localtime(&post_time));
+        strftime(time_buf, 30, "%b %e, %Y", localtime(&post_time));
         acc_sprintf("%s%-2d %s:%s %s %-12s :: %s\r\n",
             CCGRN(ch, C_NRM), count - idx, CCRED(ch, C_NRM), CCNRM(ch, C_NRM),
             time_buf, tmp_sprintf("(%s)", PQgetvalue(res, idx, 1)),


### PR DESCRIPTION
This will display the full date (month day, year) on the message list for message boards. The additional year information was added for when a message was read, but not for the list. The day of the week was also removed from the list display to conserve space, and because I can't think of a good enough reason to need to know what day of the week they wrote the post on.