### PR TITLE
Add commas to spells listed in identify spell

### DIFF
--- a/src/magic/spells.c
+++ b/src/magic/spells.c
@@ -1156,10 +1156,19 @@ ASPELL(spell_identify)
 
             if (GET_OBJ_VAL(obj, 1) >= 1)
                 send_to_char(ch, " %s", spell_to_str(GET_OBJ_VAL(obj, 1)));
+            
+            if(GET_OBJ_VAL(obj, 1) >= 1 && ((GET_OBJ_VAL(obj, 2) >= 1 || GET_OBJ_VAL(obj, 3) >= 1)))
+                send_to_char(ch, ",");
+            
             if (GET_OBJ_VAL(obj, 2) >= 1)
                 send_to_char(ch, " %s", spell_to_str(GET_OBJ_VAL(obj, 2)));
+            
+            if(GET_OBJ_VAL(obj, 2) >= 1 && GET_OBJ_VAL(obj, 3) >= 1)
+                send_to_char(ch, ",");
+            
             if (GET_OBJ_VAL(obj, 3) >= 1)
                 send_to_char(ch, " %s", spell_to_str(GET_OBJ_VAL(obj, 3)));
+            
             send_to_char(ch, "\r\n");
             break;
         case ITEM_WAND:


### PR DESCRIPTION
When using the "identify" spell on a scroll, pill, potion, or syringe, it lists the spells the object casts when used. There are no delimiters, therefore the names of the spells run together. For an experienced player this isn't an issue, but for someone relatively new to the game, a scroll that casts "blindness summon fire shield" can be confusing. A better way to display this would be "blindness, summon, fire shield".

This adds commas between the spell names for better readability and to cut down on confusion.