### PR TITLE
Add word of intellect cleric spell to affects

### DIFF
--- a/src/misc/act.informative.c
+++ b/src/misc/act.informative.c
@@ -2423,6 +2423,8 @@ acc_append_affects(struct creature *ch, int8_t mode)
         acc_strcat("You feel protected.\r\n", NULL);
     if (affected_by_spell(ch, SPELL_STRENGTH))
         acc_strcat("Your physical strength is magically augmented.\r\n", NULL);
+    if (affected_by_spell(ch, SPELL_WORD_OF_INTELLECT))
+        acc_strcat("Your intellect is magically augmented.\r\n", NULL);
     if (affected_by_spell(ch, SPELL_BARKSKIN))
         acc_strcat("Your skin is thick and tough like tree bark.\r\n", NULL);
     if (affected_by_spell(ch, SPELL_STONESKIN))


### PR DESCRIPTION
Add the cleric spell "word of intellect" to the affections list. Message mirrors what the "strength" spell displays.