### PR TITLE
Add racial night vision

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -476,6 +476,10 @@ long GET_SKILL_COST(struct creature *ch, int skill);
                                  IS_RACE(ch, RACE_DAEMON) ||    \
                                  IS_RACE(ch, RACE_RAKSHASA) || \
                                  IS_RACE(ch, RACE_ROWLAHR))
+                                 
+#define HAS_RACIAL_NIGHT_VISION(ch) (IS_ELF(ch) || IS_DROW(ch) || \
+                                     IS_DWARF(ch) || IS_ORC(ch) || \
+                                     IS_HALF_ORC(ch))
 
 #define IS_TIAMAT(ch)           (GET_NPC_VNUM(ch) == 61119)
 #define IS_TARRASQUE(ch)           (GET_NPC_VNUM(ch) == 24800)

--- a/src/util/sight.c
+++ b/src/util/sight.c
@@ -112,7 +112,8 @@ has_dark_sight(struct creature * self)
             PRF_FLAGGED(self, PRF_HOLYLIGHT) ||
             AFF3_FLAGGED(self, AFF3_SONIC_IMAGERY) ||
             AFF_FLAGGED(self, AFF_RETINA) ||
-            CHECK_SKILL(self, SKILL_NIGHT_VISION));
+            CHECK_SKILL(self, SKILL_NIGHT_VISION) ||
+            HAS_RACIAL_NIGHT_VISION(self));
 }
 
 // Returns true if the player can see in the room


### PR DESCRIPTION
This adds inherent night vision for certain races. Instead of just adding to the races.xml to give permanent magical affects, this simply lets these races see in the dark without magical intervention. Seemed more appropriate for this particular skill, as it really isn't a magical affect as much as just more sensitive eyes. This is just for the PC races that are described as being able to see in the dark.